### PR TITLE
AppChooser: misc design changes and cleanups

### DIFF
--- a/src/AppChooser/AppButton.vala
+++ b/src/AppChooser/AppButton.vala
@@ -4,38 +4,38 @@
  */
 
 public class AppChooser.AppButton : Gtk.Button {
-    public AppInfo info { get; construct; }
+    public string app_id { get; construct; }
 
     public AppButton (string app_id) {
-        Object (info: new DesktopAppInfo (app_id + ".desktop"));
+        Object (app_id: app_id);
     }
 
     construct {
+        var info = new DesktopAppInfo (app_id + ".desktop");
+
         get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
 
         var icon = new Gtk.Image () {
             gicon = info.get_icon () ?? new ThemedIcon ("x-application-default"),
-            icon_size = Gtk.IconSize.DIALOG,
-            margin_top = 9,
-            margin_end = 6,
-            margin_start = 6
+            icon_size = Gtk.IconSize.DIALOG
         };
 
         var name = new Gtk.Label (info.get_display_name ()) {
-            halign = Gtk.Align.CENTER,
+            ellipsize = Pango.EllipsizeMode.END,
             justify = Gtk.Justification.CENTER,
             lines = 2,
-            max_width_chars = 16,
-            width_chars = 16,
+            max_width_chars = 10,
+            width_chars = 10,
             wrap_mode = Pango.WrapMode.WORD_CHAR
         };
-        name.set_ellipsize (Pango.EllipsizeMode.END);
 
-        var grid = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
-            halign = Gtk.Align.CENTER
+        var grid = new Gtk.Grid () {
+            halign = Gtk.Align.CENTER,
+            margin = 6,
+            row_spacing = 6
         };
-        grid.add (icon);
-        grid.add (name);
+        grid.attach (icon, 0, 0);
+        grid.attach (name, 0, 1);
 
         add (grid);
     }

--- a/src/AppChooser/Portal.vala
+++ b/src/AppChooser/Portal.vala
@@ -43,7 +43,7 @@ public class AppChooser.Portal : Object {
             choose_application.callback ();
         });
 
-        dialog.choiced.connect ((app_id) => {
+        dialog.chosen.connect ((app_id) => {
             dialog.disconnect (destroy_id);
 
             _results["choice"] = app_id.replace (".desktop", "");


### PR DESCRIPTION
Since we're still kind of prototyping, I just jammed a bunch of shit in here. I can break it up if requested:
* Change some variable names to be clearer what data they represent
* Open an app when you click on it instead of requiring a select step. This is mainly due to some early concerns from a user who notes that it's currently very fast and easy to open an app from the context menu and they're concerned about slowing that down
* Don't include the sender in the list of options to open with
* Let the dialog be a lot more compact