### PR TITLE
SystemdUnits: Require settings portal

### DIFF
--- a/data/xdg-desktop-portal-pantheon.service.in
+++ b/data/xdg-desktop-portal-pantheon.service.in
@@ -1,5 +1,7 @@
 [Unit]
 Description=Portal service (Pantheon implementation)
+Requires=io.elementary.settings-daemon.xdg-desktop-portal.service
+After=io.elementary.settings-daemon.xdg-desktop-portal.service
 
 [Service]
 Type=dbus


### PR DESCRIPTION
Not sure if this fixes #22 but we need the settings portal to start up before us so that we can get dark style preference values