### PR TITLE
AppChooser: Redesign as a listbox

### DIFF
--- a/src/AppChooser/AppButton.vala
+++ b/src/AppChooser/AppButton.vala
@@ -3,36 +3,30 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
-public class AppChooser.AppButton : Gtk.Button {
-    public AppInfo info { get; construct; }
+public class AppChooser.AppButton : Gtk.ListBoxRow {
+    public string app_id { get; construct; }
 
     public AppButton (string app_id) {
-        Object (info: new DesktopAppInfo (app_id + ".desktop"));
+        Object (app_id: app_id);
     }
 
     construct {
-        get_style_context ().add_class (Gtk.STYLE_CLASS_FLAT);
+        var app_info = new DesktopAppInfo (app_id + ".desktop");
 
         var icon = new Gtk.Image () {
-            gicon = info.get_icon () ?? new ThemedIcon ("x-application-default"),
-            icon_size = Gtk.IconSize.DIALOG,
-            margin_top = 9,
-            margin_end = 6,
-            margin_start = 6
+            gicon = app_info.get_icon () ?? new ThemedIcon ("application-default-icon"),
+            icon_size = Gtk.IconSize.DND
         };
 
-        var name = new Gtk.Label (info.get_display_name ()) {
-            halign = Gtk.Align.CENTER,
-            justify = Gtk.Justification.CENTER,
-            lines = 2,
-            max_width_chars = 16,
-            width_chars = 16,
-            wrap_mode = Pango.WrapMode.WORD_CHAR
+        var name = new Gtk.Label (app_info.get_display_name ()) {
+            ellipsize = Pango.EllipsizeMode.END
         };
-        name.set_ellipsize (Pango.EllipsizeMode.END);
 
-        var grid = new Gtk.Box (Gtk.Orientation.VERTICAL, 6) {
-            halign = Gtk.Align.CENTER
+        var grid = new Gtk.Grid () {
+            column_spacing = 6,
+            margin = 3,
+            margin_start = 6,
+            margin_end = 6
         };
         grid.add (icon);
         grid.add (name);

--- a/src/AppChooser/Dialog.vala
+++ b/src/AppChooser/Dialog.vala
@@ -70,7 +70,7 @@ public class AppChooser.Dialog : Hdy.Window {
         };
         primary_label.get_style_context ().add_class (Granite.STYLE_CLASS_PRIMARY_LABEL);
 
-        var secondary_text = _("An application requested to open a file.");
+        var secondary_text = _("An application requested to open a %s.").printf (content_description);
         if (info != null) {
             secondary_text = _("“%s” requested to open a %s.").printf (info.get_display_name (), content_description);
         }


### PR DESCRIPTION
Redesigns the AppChooser as a listbox instead of a carousel. Since the only content this dialog has is apps, a list shows more on screen and is easier to navigate.

* Make button labels translatable
* "Select" → "Open" since we know the action here is to open in an app and not just make a selection
* Add a placeholder when the list is empty
* Set the open button insensitive when there's nothing to open