### PR TITLE
AppChooser: Make primary text translatable

### DIFF
--- a/src/AppChooser/Dialog.vala
+++ b/src/AppChooser/Dialog.vala
@@ -49,9 +49,9 @@ public class AppChooser.Dialog : Hdy.Window {
         AppInfo? info = app_id == "" ? null : new DesktopAppInfo (app_id + ".desktop");
         Hdy.init ();
 
-        var primary_text = "Open file with…";
+        var primary_text = _("Open file with…");
         if (filename != "") {
-            primary_text = "Open “%s” with…".printf (filename);
+            primary_text = _("Open “%s” with…").printf (filename);
         }
 
         var content_description = ContentType.get_description ("text/plain");


### PR DESCRIPTION
Currently the primary text of the AppChooser dialog can't be translated nor be shown as translated:

![スクリーンショット 2023-01-07 01 07 27](https://user-images.githubusercontent.com/26003928/211051023-fc47c5d4-f771-4372-bde3-2b4a2db0ef8e.png)
