### PR TITLE
Update Meson Files

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,10 +12,10 @@ jobs:
     runs-on: ubuntu-latest
     
     container:
-      image: elementary/docker:unstable
+      image: elementary/docker:next-unstable
     
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Install Dependencies
       run: |
         apt update
@@ -33,6 +33,6 @@ jobs:
       image: valalang/lint
       
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Lint
       run: io.elementary.vala-lint -d .

--- a/data/meson.build
+++ b/data/meson.build
@@ -1,6 +1,6 @@
 install_data(
     'pantheon.portal',
-    install_dir: join_paths(datadir, 'xdg-desktop-portal', 'portals')
+    install_dir: datadir / 'xdg-desktop-portal' / 'portals'
 )
 
 configure_file(
@@ -8,12 +8,12 @@ configure_file(
     output: '@BASENAME@',
     configuration: conf_data,
     install: true,
-    install_dir: join_paths(datadir, 'dbus-1', 'services')
+    install_dir: datadir / 'dbus-1' / 'services'
 )
 
-systemd_systemduserunitdir = get_option('systemduserunitdir')
-if systemd_systemduserunitdir == ''
-    systemd_systemduserunitdir = systemd_dep.get_pkgconfig_variable('systemduserunitdir', define_variable: ['prefix', prefix])
+systemduserunitdir = get_option('systemduserunitdir')
+if systemduserunitdir == ''
+    systemduserunitdir = systemd_dep.get_variable('systemduserunitdir', pkgconfig_define: [ 'prefix', prefix ])
 endif
 
 configure_file(
@@ -21,14 +21,14 @@ configure_file(
     output: '@BASENAME@',
     configuration: conf_data,
     install: true,
-    install_dir: systemd_systemduserunitdir
+    install_dir: systemduserunitdir
 )
 
 i18n.merge_file(
     input: 'portals.appdata.xml.in',
     output: 'io.elementary.portals.appdata.xml',
-    po_dir: join_paths(meson.source_root(), 'po', 'extra'),
+    po_dir: meson.project_source_root() / 'po' / 'extra',
     type: 'xml',
     install: true,
-    install_dir: join_paths(get_option('datadir'), 'metainfo'),
+    install_dir: datadir / 'metainfo'
 )

--- a/meson.build
+++ b/meson.build
@@ -1,11 +1,11 @@
-project('xdg-desktop-portal-pantheon', 'c', 'vala', version: '1.2.0')
+project('xdg-desktop-portal-pantheon', 'c', 'vala', version: '1.2.0', meson_version: '>=0.58')
 
 i18n = import('i18n')
 
 prefix = get_option('prefix')
-datadir = join_paths(prefix, get_option('datadir'))
-libexecdir = join_paths(prefix, get_option('libexecdir'))
-localedir = join_paths(prefix, get_option('localedir'))
+datadir = prefix / get_option('datadir')
+libexecdir = prefix / get_option('libexecdir')
+localedir = prefix / get_option('localedir')
 
 systemd_dep = dependency('systemd')
 
@@ -23,7 +23,7 @@ add_project_arguments(
     language: 'vala'
 )
 
-add_global_arguments(
+add_project_arguments(
     '-DGETTEXT_PACKAGE="@0@"'.format (meson.project_name()),
     language: 'c'
 )

--- a/po/extra/meson.build
+++ b/po/extra/meson.build
@@ -1,5 +1,1 @@
-i18n.gettext('extra',
-    args: ['--directory='+meson.source_root()],
-    install: false,
-    preset: 'glib'
-)
+i18n.gettext('extra', install: false, preset: 'glib')

--- a/po/meson.build
+++ b/po/meson.build
@@ -1,5 +1,3 @@
-i18n.gettext(meson.project_name(),
-    args: ['--directory='+meson.source_root()],
-    preset: 'glib'
-)
+i18n.gettext(meson.project_name(), preset: 'glib')
+
 subdir('extra')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,20 +1,14 @@
-conf_file = configure_file(
-    input: 'Config.vala.in',
-    output: '@BASENAME@',
-    configuration: conf_data
-)
-
 executable(
     meson.project_name(),
-    conf_file,
-    'XdgDesktopPortalPantheon.vala',
-    'ExternalWindow.vala',
-    'Access/Portal.vala',
-    'Access/Dialog.vala',
     'Access/Choice.vala',
-    'AppChooser/Portal.vala',
-    'AppChooser/Dialog.vala',
+    'Access/Dialog.vala',
+    'Access/Portal.vala',
     'AppChooser/AppButton.vala',
+    'AppChooser/Dialog.vala',
+    'AppChooser/Portal.vala',
+    configure_file(input: 'Config.vala.in', output: '@BASENAME@', configuration: conf_data),
+    'ExternalWindow.vala',
+    'XdgDesktopPortalPantheon.vala',
     dependencies: [
         glib_dep,
         gobject_dep,
@@ -26,5 +20,5 @@ executable(
         handy_dep
     ],
     install: true,
-    install_dir: libexecdir,
+    install_dir: libexecdir
 )


### PR DESCRIPTION
* make use of the `/` join separator everywhere
* sort source files following the meson's style recomendations
* remove unnecessary args from `i18n.gettext()`
* set minimum meson version to 0.58
* don't use deprecated functions