### PR TITLE
Access: Minor Rework

### DIFF
--- a/src/Access/Dialog.vala
+++ b/src/Access/Dialog.vala
@@ -92,6 +92,11 @@ public class Access.Dialog : Granite.MessageDialog {
         toplevel.focus (Gdk.CURRENT_TIME);
     }
 
+    public override void close () {
+        response (Gtk.ResponseType.CANCEL);
+        base.close ();
+    }
+
     [DBus (visible = false)]
     public void add_choice (Choice choice) {
         choices.append (choice);

--- a/src/Access/Dialog.vala
+++ b/src/Access/Dialog.vala
@@ -36,8 +36,8 @@ public class Access.Dialog : Granite.MessageDialog {
         }
     }
 
-    private Gtk.Button grant_button;
-    private Gtk.Button deny_button;
+    private unowned Gtk.Button grant_button;
+    private unowned Gtk.Button deny_button;
     private List<Choice> choices;
 
     public Dialog (ButtonAction action, string app_id, string parent_window, string icon) {
@@ -73,27 +73,23 @@ public class Access.Dialog : Granite.MessageDialog {
 
         custom_bin.orientation = Gtk.Orientation.VERTICAL;
         custom_bin.spacing = 6;
+    }
+
+    public override void show () {
+        ((Gtk.Widget) base).realize ();
+
+        unowned var toplevel = (Gdk.Toplevel) get_surface ();
 
         if (parent_window != "") {
-            ((Gtk.Widget) this).realize.connect (() => {
-                unowned var surface = get_surface ();
-
-                if (surface is Gdk.X11.Surface) {
-                    unowned var x11_surface = (Gdk.X11.Surface) surface;
-                    x11_surface.set_skip_taskbar_hint (true);
-                }
-
-                try {
-                    ExternalWindow.from_handle (parent_window).set_parent_of (surface);
-                } catch (Error e) {
-                    warning ("Failed to associate portal window with parent %s: %s", parent_window, e.message);
-                }
-            });
+            try {
+                ExternalWindow.from_handle (parent_window).set_parent_of (toplevel);
+            } catch (Error e) {
+                warning ("Failed to associate portal window with parent '%s': %s", parent_window, e.message);
+            }
         }
 
-        show.connect (() => {
-            present_with_time (Gdk.CURRENT_TIME);
-        });
+        base.show ();
+        toplevel.focus (Gdk.CURRENT_TIME);
     }
 
     [DBus (visible = false)]

--- a/src/Access/Dialog.vala
+++ b/src/Access/Dialog.vala
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2021-2023 elementary, Inc. (https://elementary.io)
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
@@ -9,8 +9,6 @@ public class Access.Dialog : Granite.MessageDialog {
         SUGGESTED,
         DESTRUCTIVE
     }
-
-    public uint register_id { get; set; default = 0; }
 
     public ButtonAction action { get; construct; }
 

--- a/src/Access/Portal.vala
+++ b/src/Access/Portal.vala
@@ -92,8 +92,9 @@ public class Access.Portal : Object {
 
         try {
             register_id = connection.register_object (handle, dialog);
-        } catch (Error e) {
-            critical (e.message);
+        } catch (IOError e) {
+            warning (e.message);
+            throw new DBusError.OBJECT_PATH_IN_USE (e.message);
         }
 
         dialog.present ();

--- a/src/Access/Portal.vala
+++ b/src/Access/Portal.vala
@@ -62,19 +62,13 @@ public class Access.Portal : Object {
             }
         }
 
-        try {
-            register_id = connection.register_object (handle, dialog);
-        } catch (Error e) {
-            critical (e.message);
-        }
-
         var _results = new HashTable<string, Variant> (str_hash, str_equal);
-        uint _response = 2;
+        var _response = 2;
 
         dialog.response.connect ((id) => {
             switch (id) {
                 case Gtk.ResponseType.OK:
-                    VariantBuilder choices_builder = new VariantBuilder (new VariantType ("a(ss)"));
+                    var choices_builder = new VariantBuilder (new VariantType ("a(ss)"));
 
                     dialog.get_choices ().foreach ((choice) => {
                         choices_builder.add ("(ss)", choice.name, choice.selected);
@@ -83,9 +77,11 @@ public class Access.Portal : Object {
                     _results["choices"] = choices_builder.end ();
                     _response = 0;
                     break;
+
                 case Gtk.ResponseType.CANCEL:
                     _response = 1;
                     break;
+
                 case Gtk.ResponseType.DELETE_EVENT:
                     _response = 2;
                     break;
@@ -93,6 +89,12 @@ public class Access.Portal : Object {
 
             access_dialog.callback ();
         });
+
+        try {
+            register_id = connection.register_object (handle, dialog);
+        } catch (Error e) {
+            critical (e.message);
+        }
 
         dialog.present ();
         yield;

--- a/src/Access/Portal.vala
+++ b/src/Access/Portal.vala
@@ -1,5 +1,5 @@
 /*
- * SPDX-FileCopyrightText: 2021 elementary, Inc. (https://elementary.io)
+ * SPDX-FileCopyrightText: 2021-2023 elementary, Inc. (https://elementary.io)
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
@@ -24,6 +24,7 @@ public class Access.Portal : Object {
     ) throws DBusError, IOError {
         Dialog.ButtonAction action = Dialog.ButtonAction.SUGGESTED;
         string icon = "dialog-information";
+        uint register_id = 0;
 
         if ("destructive" in options && options["destructive"].get_boolean ()) {
             action = Dialog.ButtonAction.DESTRUCTIVE;
@@ -62,7 +63,7 @@ public class Access.Portal : Object {
         }
 
         try {
-            dialog.register_id = connection.register_object (handle, dialog);
+            register_id = connection.register_object (handle, dialog);
         } catch (Error e) {
             critical (e.message);
         }
@@ -96,7 +97,7 @@ public class Access.Portal : Object {
         dialog.present ();
         yield;
 
-        connection.unregister_object (dialog.register_id);
+        connection.unregister_object (register_id);
         dialog.destroy ();
 
         results = _results;


### PR DESCRIPTION
Some minimal changes to the access classes, the more siginificant one is that we don't set skip_taskbar_hint anymore since that is a X11-only feature and actually could make find the dialog a bit hader if it was open as non-modal and another window take focus.