### PR TITLE
Add build support for older Vala versions

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -13,9 +13,18 @@ glib_dep = dependency('glib-2.0')
 gobject_dep = dependency('gobject-2.0')
 gio_dep = dependency('gio-2.0')
 granite_dep = dependency('granite-7')
-gtk_dep = dependency('gtk4')
-gtk_x11_dep = dependency('gtk4-x11')
-wayland_dep = dependency('gtk4-wayland')
+
+gtk_deps = [
+    dependency('gtk4')
+]
+
+if meson.get_compiler('vala').version().version_compare('>=0.56.1')
+    gtk_deps += [
+        dependency('gtk4-x11'),
+        dependency('gtk4-wayland')
+    ]
+endif
+
 x11_dep = dependency('x11')
 
 add_project_arguments(

--- a/src/meson.build
+++ b/src/meson.build
@@ -14,9 +14,7 @@ executable(
         gobject_dep,
         gio_dep,
         granite_dep,
-        gtk_dep,
-        gtk_x11_dep,
-        wayland_dep,
+        gtk_deps,
         x11_dep
     ],
     install: true,


### PR DESCRIPTION
elementary OS uses a more recent version of Vala than the base version of Ubuntu provides. Therefore it is currently not possible to build this project on Ubuntu 22.04.

[Since Vala 0.56.1 gtk4-wayland and gtk4-x11 are split out into separate bindings](https://gitlab.gnome.org/GNOME/vala/-/blob/85f1f0fd60ce41a3d7bf0bd441a7ce383a1a7af4/NEWS#L107).

This fixes the issue for older Vala versions:

[Before](https://github.com/meisenzahl/distro-agnostic/actions/runs/4713764872/jobs/8359675236#step:5:4269)

[After](https://github.com/meisenzahl/distro-agnostic/actions/runs/4714451958/jobs/8360828237#step:5:3540)