### PR TITLE
Respect user autostart options

### DIFF
--- a/src/Background/Portal.vala
+++ b/src/Background/Portal.vala
@@ -152,6 +152,7 @@ public class Background.Portal : Object {
         }
 
         bool hidden = false;
+
         if (file.query_exists ()) {
             try {
                 uint8[] contents;

--- a/src/Background/Portal.vala
+++ b/src/Background/Portal.vala
@@ -151,6 +151,23 @@ public class Background.Portal : Object {
             return false;
         }
 
+        bool hidden = false;
+        if (file.query_exists ()) {
+            try {
+                uint8[] contents;
+                yield file.load_contents_async (null, out contents, null);
+
+                var old_keyfile = new KeyFile ();
+                old_keyfile.load_from_data ((string) contents, contents.length, NONE);
+
+                if (old_keyfile.has_key (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN)) {
+                    hidden = old_keyfile.get_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN);
+                }
+            } catch (Error e) {
+                warning ("Failed to load exisiting autostart file: %s", e.message);
+            }
+        }
+
         var key_file = new KeyFile ();
         key_file.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_TYPE, KeyFileDesktop.TYPE_APPLICATION);
 
@@ -170,6 +187,8 @@ public class Background.Portal : Object {
         if (app_id != "") {
             key_file.set_string (KeyFileDesktop.GROUP, "X-Flatpak", app_id);
         }
+
+        key_file.set_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN, hidden);
 
         FileCreateFlags create_flags = PRIVATE | REPLACE_DESTINATION;
         var contents = key_file.to_data ();

--- a/src/Background/Portal.vala
+++ b/src/Background/Portal.vala
@@ -151,24 +151,6 @@ public class Background.Portal : Object {
             return false;
         }
 
-        bool hidden = false;
-
-        if (file.query_exists ()) {
-            try {
-                uint8[] contents;
-                yield file.load_contents_async (null, out contents, null);
-
-                var old_keyfile = new KeyFile ();
-                old_keyfile.load_from_data ((string) contents, contents.length, NONE);
-
-                if (old_keyfile.has_key (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN)) {
-                    hidden = old_keyfile.get_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN);
-                }
-            } catch (Error e) {
-                warning ("Failed to load exisiting autostart file: %s", e.message);
-            }
-        }
-
         var key_file = new KeyFile ();
         key_file.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_TYPE, KeyFileDesktop.TYPE_APPLICATION);
 
@@ -189,7 +171,22 @@ public class Background.Portal : Object {
             key_file.set_string (KeyFileDesktop.GROUP, "X-Flatpak", app_id);
         }
 
-        key_file.set_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN, hidden);
+        if (file.query_exists ()) {
+            try {
+                uint8[] contents;
+                yield file.load_contents_async (null, out contents, null);
+
+                var old_keyfile = new KeyFile ();
+                old_keyfile.load_from_data ((string) contents, contents.length, NONE);
+
+                if (old_keyfile.has_key (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN)) {
+                    var hidden = old_keyfile.get_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN);
+                    key_file.set_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN, hidden);
+                }
+            } catch (Error e) {
+                warning ("Failed to load exisiting autostart file: %s", e.message);
+            }
+        }
 
         FileCreateFlags create_flags = PRIVATE | REPLACE_DESTINATION;
         var contents = key_file.to_data ();

--- a/src/Background/Portal.vala
+++ b/src/Background/Portal.vala
@@ -152,6 +152,18 @@ public class Background.Portal : Object {
         }
 
         var key_file = new KeyFile ();
+
+        if (file.query_exists ()) {
+            try {
+                uint8[] contents;
+                yield file.load_contents_async (null, out contents, null);
+
+                key_file.load_from_data ((string) contents, contents.length, KEEP_COMMENTS | KEEP_TRANSLATIONS);
+            } catch (Error e) {
+                warning ("Failed to load exisiting autostart file: %s", e.message);
+            }
+        }
+
         key_file.set_string (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_TYPE, KeyFileDesktop.TYPE_APPLICATION);
 
         if (app_info != null) {
@@ -169,23 +181,6 @@ public class Background.Portal : Object {
 
         if (app_id != "") {
             key_file.set_string (KeyFileDesktop.GROUP, "X-Flatpak", app_id);
-        }
-
-        if (file.query_exists ()) {
-            try {
-                uint8[] contents;
-                yield file.load_contents_async (null, out contents, null);
-
-                var old_keyfile = new KeyFile ();
-                old_keyfile.load_from_data ((string) contents, contents.length, NONE);
-
-                if (old_keyfile.has_key (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN)) {
-                    var hidden = old_keyfile.get_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN);
-                    key_file.set_boolean (KeyFileDesktop.GROUP, KeyFileDesktop.KEY_HIDDEN, hidden);
-                }
-            } catch (Error e) {
-                warning ("Failed to load exisiting autostart file: %s", e.message);
-            }
         }
 
         FileCreateFlags create_flags = PRIVATE | REPLACE_DESTINATION;


### PR DESCRIPTION
Currently disabling autostart for an app like mail via startup settings gets reverted every time the app is launched again because the app then asks for autostart permission again and the autostart file is entirely overwritten. To disable it one would have to revoke the flatpak permission which currently can't be done graphically without third party tools. Also this wouldn't work for non flatpak applications. 
With this PR we check whether an autostart file already exists and if so we check whether it has the hidden key and add it to the new autostart file. We still overwrite it completely to avoid keeping other keys we might not want (I'm not 100% sure whether that's really necessary but it seems the most save way)