### PR TITLE
Approval dialog design, setup dialog fixes

### DIFF
--- a/src/Screenshot/ApprovalDialog.vala
+++ b/src/Screenshot/ApprovalDialog.vala
@@ -3,21 +3,26 @@
  * SPDX-License-Identifier: LGPL-2.1-or-later
  */
 
- public class Screenshot.ApprovalDialog : Gtk.Window {
-    public signal void response (Gtk.ResponseType response_type);
-
+ public class Screenshot.ApprovalDialog : Granite.MessageDialog {
     public string parent_window { get; construct; }
-    public string app_id { get; construct; }
     public string screenshot_uri { get; construct; }
 
     public ApprovalDialog (string parent_window, bool modal, string app_id, string screenshot_uri) {
         Object (
-            resizable: false,
             parent_window: parent_window,
             modal: modal,
-            app_id: app_id,
-            screenshot_uri: screenshot_uri
+            screenshot_uri: screenshot_uri,
+            primary_text: _("Share this screenshot with the requesting app?"),
+            secondary_text: _("Only the app which requested this screenshot will be able to see it. This screenshot will not be saved elsewhere."),
+            buttons: Gtk.ButtonsType.CANCEL
         );
+
+        if (app_id != null) {
+            var app_info = new GLib.DesktopAppInfo (app_id + ".desktop");
+            if (app_info != null) {
+                primary_text = _("Share this screenshot with “%s”?").printf (app_info.get_display_name ());
+            }
+        }
     }
 
     construct {
@@ -31,79 +36,21 @@
             });
         }
 
-        var title = new Gtk.Label (_("Share Screenshot")) {
-            max_width_chars = 0, // Wrap, but secondary label sets the width
-            selectable = true,
-            wrap = true,
-            xalign = 0
-        };
-        title.add_css_class (Granite.STYLE_CLASS_TITLE_LABEL);
-
-        var subtitle = new Gtk.Label (_("Share this screenshot with the requesting app?")) {
-            max_width_chars = 50,
-            width_chars = 50, // Prevents a bug where extra height is preserved
-            selectable = true,
-            wrap = true,
-            xalign = 0
-        };
-
-        if (app_id != null) {
-            var app_info = new GLib.DesktopAppInfo (app_id + ".desktop");
-            if (app_info != null) {
-                subtitle.label = _("Share this screenshot with %s?").printf (app_info.get_display_name ());
-            }
-        }
+        image_icon = new ThemedIcon ("io.elementary.screenshot");
 
         var screenshot_filename = GLib.Filename.from_uri (screenshot_uri);
-        var screenshot_image = new Gtk.Picture.for_pixbuf (new Gdk.Pixbuf.from_file_at_scale (screenshot_filename, 384, 384, true)) {
+        var screenshot_image = new Gtk.Picture.for_pixbuf (new Gdk.Pixbuf.from_file_at_scale (screenshot_filename, 400, 400, true)) {
+            overflow = HIDDEN,
+            width_request = 400
         };
+        screenshot_image.add_css_class (Granite.STYLE_CLASS_CARD);
+        screenshot_image.add_css_class (Granite.STYLE_CLASS_ROUNDED);
+        screenshot_image.add_css_class (Granite.STYLE_CLASS_CHECKERBOARD);
 
-        var allow_button = new Gtk.Button.with_label (_("Share Screenshot")) {
-            receives_default = true
-        };
+        var allow_button = add_button (_("Share Screenshot"), Gtk.ResponseType.OK);
+        allow_button.receives_default = true;
         allow_button.add_css_class (Granite.STYLE_CLASS_SUGGESTED_ACTION);
 
-        allow_button.clicked.connect (() => {
-            response (Gtk.ResponseType.OK);
-        });
-
-        var close_btn = new Gtk.Button.with_label (_("Close"));
-
-        var actions = new Gtk.Box (HORIZONTAL, 6) {
-            halign = END,
-            homogeneous = true
-        };
-        actions.append (close_btn);
-        actions.append (allow_button);
-
-        var box = new Gtk.Box (VERTICAL, 24) {
-            margin_top = 24,
-            margin_end = 12,
-            margin_bottom = 12,
-            margin_start = 12
-        };
-        box.add_css_class ("dialog-vbox");
-        box.append (title);
-        box.append (subtitle);
-        box.append (screenshot_image);
-        box.append (actions);
-
-        var window_handle = new Gtk.WindowHandle () {
-            child = box
-        };
-
-        child = window_handle;
-
-        // We need to hide the title area
-        titlebar = new Gtk.Grid () {
-            visible = false
-        };
-
-        add_css_class ("dialog");
-        add_css_class (Granite.STYLE_CLASS_MESSAGE_DIALOG);
-
-        close_btn.clicked.connect (() => {
-            response (Gtk.ResponseType.CLOSE);
-        });
+        custom_bin.append (screenshot_image);
     }
 }

--- a/src/Screenshot/SetupDialog.vala
+++ b/src/Screenshot/SetupDialog.vala
@@ -114,7 +114,7 @@ public class Screenshot.SetupDialog : Gtk.Window {
 
         var redact_label = new Gtk.Label (_("Conceal text:")) {
             halign = END,
-            mnemonic_widget = redact_switch 
+            mnemonic_widget = redact_switch
         };
 
         var delay_spin = new Gtk.SpinButton.with_range (0, 15, 1);

--- a/src/Screenshot/SetupDialog.vala
+++ b/src/Screenshot/SetupDialog.vala
@@ -40,7 +40,9 @@ public class Screenshot.SetupDialog : Gtk.Window {
             });
         }
 
-        all_image = new Gtk.Image.from_icon_name ("grab-screen-symbolic");
+        all_image = new Gtk.Image.from_icon_name ("grab-screen-symbolic") {
+            icon_size = LARGE
+        };
 
         var all = new Gtk.CheckButton () {
             active = true,
@@ -55,7 +57,9 @@ public class Screenshot.SetupDialog : Gtk.Window {
             }
         });
 
-        var curr_image = new Gtk.Image.from_icon_name ("grab-window-symbolic");
+        var curr_image = new Gtk.Image.from_icon_name ("grab-window-symbolic") {
+            icon_size = LARGE
+        };
 
         var curr_window = new Gtk.CheckButton () {
             group = all,
@@ -70,7 +74,9 @@ public class Screenshot.SetupDialog : Gtk.Window {
             }
         });
 
-        var selection_image = new Gtk.Image.from_icon_name ("grab-area-symbolic");
+        var selection_image = new Gtk.Image.from_icon_name ("grab-area-symbolic") {
+            icon_size = LARGE
+        };
 
         var selection = new Gtk.CheckButton () {
             group = all,
@@ -85,10 +91,6 @@ public class Screenshot.SetupDialog : Gtk.Window {
             }
         });
 
-        var pointer_label = new Gtk.Label (_("Grab pointer:")) {
-            halign = END
-        };
-
         var pointer_switch = new Gtk.Switch () {
             halign = START
         };
@@ -97,8 +99,9 @@ public class Screenshot.SetupDialog : Gtk.Window {
             grab_pointer = pointer_switch.active;
         });
 
-        var redact_label = new Gtk.Label (_("Conceal text:")) {
-            halign = END
+        var pointer_label = new Gtk.Label (_("Grab pointer:")) {
+            halign = END,
+            mnemonic_widget = pointer_switch
         };
 
         var redact_switch = new Gtk.Switch () {
@@ -109,14 +112,21 @@ public class Screenshot.SetupDialog : Gtk.Window {
             redact_text = redact_switch.active;
         });
 
-        var delay_label = new Gtk.Label (_("Delay in seconds:"));
-        delay_label.halign = Gtk.Align.END;
+        var redact_label = new Gtk.Label (_("Conceal text:")) {
+            halign = END,
+            mnemonic_widget = redact_switch 
+        };
 
         var delay_spin = new Gtk.SpinButton.with_range (0, 15, 1);
 
         delay_spin.value_changed.connect (() => {
             delay = (int) delay_spin.value;
         });
+
+        var delay_label = new Gtk.Label (_("Delay in seconds:")) {
+            halign = END,
+            mnemonic_widget = delay_spin
+        };
 
         var take_btn = new Gtk.Button.with_label (_("Take Screenshot")) {
             receives_default = true


### PR DESCRIPTION

![Screenshot from 2023-12-13 12 37 36](https://github.com/elementary/portals/assets/7277719/b7dc4434-7b57-41a5-a7a7-eebc0db50448)
![Screenshot from 2023-12-13 12 37 23](https://github.com/elementary/portals/assets/7277719/444d446c-a956-4afe-ad3f-97eb37a5798e)

**Approval Dialog**
* Subclass Granite.MessageDialog. Is there a reason it was a Window subclass before?
* Make the big question the primary text and secondary explains any consequences, outcomes, etc
* Add checkerboard and card classes to screenshot preview so we handle transparent screenshots too
* "Close" → "Cancel" so we have a more clear outcome

**Setup Dialog**
* Fix icon sizes
* Set mnemonic widgets for screen reader