### PR TITLE
Screencast/SelectionRow: Use app name, style

### DIFF
--- a/src/ScreenCast/Dialog.vala
+++ b/src/ScreenCast/Dialog.vala
@@ -36,8 +36,9 @@ public class ScreenCast.Dialog : Granite.Dialog {
             var monitor_tracker = new MonitorTracker ();
 
             foreach (var monitor in monitor_tracker.monitors) {
-                var row = new SelectionRow (MONITOR, monitor.connector,
-                    monitor.display_name, null, allow_multiple ? null : group);
+                var row = new SelectionRow (
+                    MONITOR, monitor.connector, monitor.display_name, new ThemedIcon ("video-display"), allow_multiple ? null : group
+                );
 
                 monitor_rows.append (row);
                 setup_row (row);
@@ -95,21 +96,29 @@ public class ScreenCast.Dialog : Granite.Dialog {
 
         foreach (var window in windows) {
             var label = _("Unknown Window");
+            string? description = null;
 
             if ("title" in window.details) {
                 label = (string) window.details["title"];
             }
 
-            Icon icon = new ThemedIcon ("application-x-executable");
+            Icon icon = new ThemedIcon ("application-default-icon");
             if ("app-id" in window.details) {
                 var app_info = new DesktopAppInfo ((string) window.details["app-id"]);
                 if (app_info != null && app_info.get_icon () != null) {
                     icon = app_info.get_icon ();
+                    description = label;
+                    label = app_info.get_display_name ();
                 }
             }
 
-            var row = new SelectionRow (WINDOW, window.uid,
-                label, icon, allow_multiple ? null : group);
+            var row = new SelectionRow (
+                WINDOW, window.uid, label, icon, allow_multiple ? null : group
+            );
+
+            if (description != null) {
+                row.description = description;
+            }
 
             window_rows.append (row);
             setup_row (row);

--- a/src/ScreenCast/SelectionRow.vala
+++ b/src/ScreenCast/SelectionRow.vala
@@ -9,14 +9,32 @@ public class ScreenCast.SelectionRow : Gtk.ListBoxRow {
     public SourceType source_type { get; construct; }
     public Variant id { get; construct; }
     public string label { get; construct; }
-    public Icon? icon { get; construct; }
+    public Icon icon { get; construct; }
     public Gtk.CheckButton? group { get; construct; }
 
     public Gtk.CheckButton check_button { get; construct; }
 
     public bool selected { get; set; default = false; }
 
-    public SelectionRow (SourceType source_type, Variant id, string label, Icon? icon, Gtk.CheckButton? group) {
+    public string description {
+        set {
+            var description_label = new Gtk.Label (value) {
+                ellipsize = MIDDLE,
+                hexpand = true,
+                lines = 2,
+                wrap = true,
+                xalign = 0
+            };
+            description_label.add_css_class (Granite.STYLE_CLASS_DIM_LABEL);
+            description_label.add_css_class (Granite.STYLE_CLASS_SMALL_LABEL);
+
+            label_box.append (description_label);
+        }
+    }
+
+    private Gtk.Box label_box;
+
+    public SelectionRow (SourceType source_type, Variant id, string label, Icon icon, Gtk.CheckButton? group) {
         Object (
             source_type: source_type,
             id: id,
@@ -27,17 +45,29 @@ public class ScreenCast.SelectionRow : Gtk.ListBoxRow {
     }
 
     construct {
-        var box = new Gtk.Box (HORIZONTAL, 6);
+        check_button = new Gtk.CheckButton () {
+            group = group
+        };
 
-        check_button = new Gtk.CheckButton ();
+        var image = new Gtk.Image.from_gicon (icon) {
+            icon_size = LARGE
+        };
+
+        var title_label = new Gtk.Label (label) {
+            ellipsize = MIDDLE,
+            xalign = 0
+        };
+
+        label_box = new Gtk.Box (VERTICAL, 0) {
+            margin_start = 6,
+            valign = CENTER
+        };
+        label_box.append (title_label);
+
+        var box = new Gtk.Box (HORIZONTAL, 0);
         box.append (check_button);
-        check_button.set_group (group);
-
-        if (icon != null) {
-            box.append (new Gtk.Image.from_gicon (icon));
-        }
-
-        box.append (new Gtk.Label (label) { ellipsize = MIDDLE });
+        box.append (image);
+        box.append (label_box);
 
         child = box;
 

--- a/src/XdgDesktopPortalPantheon.vala
+++ b/src/XdgDesktopPortalPantheon.vala
@@ -88,6 +88,7 @@ int main (string[] args) {
     GLib.Environment.unset_variable ("GTK_USE_PORTAL");
 
     Gtk.init ();
+    Granite.init ();
 
     weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
     default_theme.add_resource_path ("/io/elementary/xdg-desktop-portal-pantheon");


### PR DESCRIPTION
* Use app name when available
* We need to Granite.init to load styles for headers etc
* Add an icon for displays

## BEFORE

![Screenshot from 2025-06-11 14 15 16](https://github.com/user-attachments/assets/39fc3a54-6e2a-4ecb-a7b3-16379053dd49)

## AFTER

![Screenshot from 2025-06-11 14 37 20](https://github.com/user-attachments/assets/7f7b5d53-cab5-4af3-a12d-0afc05787f98)
