### PR TITLE
XdgDesktopPortalPantheon: Do not access to xdg-desktop-portal before its fully initialized

### DIFF
--- a/src/XdgDesktopPortalPantheon.vala
+++ b/src/XdgDesktopPortalPantheon.vala
@@ -63,6 +63,8 @@ private void on_name_acquired () {
     // appearing before binding the style scheme
     uint watch_id = 0;
     watch_id = Bus.watch_name (BusType.SESSION, "org.freedesktop.portal.Desktop", BusNameWatcherFlags.NONE, () => {
+        Granite.init ();
+
         var granite_settings = Granite.Settings.get_default ();
         var gtk_settings = Gtk.Settings.get_default ();
 
@@ -88,7 +90,6 @@ int main (string[] args) {
     GLib.Environment.unset_variable ("GTK_USE_PORTAL");
 
     Gtk.init ();
-    Granite.init ();
 
     weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
     default_theme.add_resource_path ("/io/elementary/xdg-desktop-portal-pantheon");


### PR DESCRIPTION
Fixes #143

`Granite.init ()` tries to access the `org.freedesktop.appearance` portal internally ([link](https://github.com/elementary/granite/blob/66c5fec8b4fd046d44c7122416595605594b9591/lib/Widgets/Settings.vala#L154-L163)). However, in the `main()` of our portal xdg-desktop-portal that provides `org.freedesktop.appearance` is not fully initialized, causing the chicken and the egg problem.
