### PR TITLE
metainfo: Add release note for 8.0.4

### DIFF
--- a/data/portals.metainfo.xml.in
+++ b/data/portals.metainfo.xml.in
@@ -26,7 +26,16 @@
   <update_contact>contact_at_elementary.io</update_contact>
 
   <releases>
-      <release version="8.0.3" data="2025-06-12" urgency="medium">
+    <release version="8.0.4" data="2025-06-17" urgency="medium">
+      <description>
+        <p>Fixes a regression in 8.0.3 that happens with unreleased version of Granite</p>
+      </description>
+      <issues>
+        <issue url="https://github.com/elementary/portals/issues/143">#140 causes delay until the desktop is shown on login</issue>
+      </issues>
+    </release>
+
+    <release version="8.0.3" data="2025-06-12" urgency="medium">
       <description>
         <p>New Features:</p>
         <ul>


### PR DESCRIPTION
The regression is not critical because it just have users just keep waiting for the desktop for a minute only with unreleased version of Granite, but I think we should release 8.0.4 in a few days in case we release Granite in the near future without releasing Portal
