### PR TITLE
Screenshot: set title and icon name

### DIFF
--- a/src/Screenshot/SetupDialog.vala
+++ b/src/Screenshot/SetupDialog.vala
@@ -201,6 +201,8 @@ public class Screenshot.SetupDialog : Gtk.Window {
         };
 
         child = window_handle;
+        icon_name = "accessories-screenshot-tool";
+        title = _("Screenshot");
 
         // We need to hide the title area
         titlebar = new Gtk.Grid () {


### PR DESCRIPTION
so that screenshot windows don't show as "xdg-desktop-portal-pantheon"