### PR TITLE
Initialize gtk later

### DIFF
--- a/src/XdgDesktopPortalPantheon.vala
+++ b/src/XdgDesktopPortalPantheon.vala
@@ -68,6 +68,9 @@ private void on_name_acquired () {
     watch_id = Bus.watch_name (BusType.SESSION, "org.freedesktop.portal.Desktop", BusNameWatcherFlags.NONE, () => {
         Granite.init ();
 
+        weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
+        default_theme.add_resource_path ("/io/elementary/xdg-desktop-portal-pantheon/icons");
+
         var css_provider = new Gtk.CssProvider ();
         css_provider.load_from_resource ("/io/elementary/xdg-desktop-portal-pantheon/Application.css");
         Gtk.StyleContext.add_provider_for_display (Gdk.Display.get_default (), css_provider, Gtk.STYLE_PROVIDER_PRIORITY_APPLICATION);
@@ -95,11 +98,6 @@ int main (string[] args) {
 
     /* Avoid pointless and confusing recursion */
     GLib.Environment.unset_variable ("GTK_USE_PORTAL");
-
-    Gtk.init ();
-
-    weak Gtk.IconTheme default_theme = Gtk.IconTheme.get_for_display (Gdk.Display.get_default ());
-    default_theme.add_resource_path ("/io/elementary/xdg-desktop-portal-pantheon/icons");
 
     try {
         var opt_context = new OptionContext ("- portal backends");


### PR DESCRIPTION
Should fix #157 

During initialization GDK tries to find settings portal, but since it isn't started yet, the whole GTK init freezes till timeout. Not sure whether this is the solution because while it fixes the initial startup of the portal, trying to restart the portal would freeze the entire desktop for the same 25 seconds 🫠️