### PR TITLE
ScreenCast: follow spec naming

### DIFF
--- a/src/ScreenCast/Portal.vala
+++ b/src/ScreenCast/Portal.vala
@@ -23,6 +23,7 @@ public enum ScreenCast.CursorMode {
 public class ScreenCast.Portal : Object {
     public SourceType available_source_types { get; default = MONITOR | WINDOW | VIRTUAL; }
     public CursorMode available_cursor_modes { get; default = HIDDEN | EMBEDDED | METADATA; }
+    [DBus (name = "version")]
     public uint version { get; default = 3; }
 
     private DBusConnection connection;


### PR DESCRIPTION
tl;dr: follow x-d-p spec

Long version: By default vala translates dbus members from snake case to pascal case, and that's totally ok for most of the time. But this behavior bites us here since x-d-p expects `version` property to be lowercase. Before x-d-p 1.21 it wasn't an issue because they've set their version independently from us. But now they conditionally bind portal's properties to implementations (us). Since cursor capture was added with version 2, this all caused a mismatch of properties and confusion of clients, because we were reporting correct `AvailableCursorModes` but portal didn't know about this assuming we "supported" old version of the spec.